### PR TITLE
add source code to match the source maps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,5 @@ coverage/
 .nvmrc
 jest.config.js
 tsconfig.json
-src/
 **/__tests__/**
 **/examples/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bessonovs/node-http-router",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "Extensible http router for node and micro",
 	"keywords": [
 		"router",


### PR DESCRIPTION
source maps pointing to non-existent files aren't
good. Instead of embedding source code inside
source maps with the option inlineSourceMap,
probably, it's better to provide source files,
because sometimes devs want to look at source
code without switching terminal or search for
github repo.